### PR TITLE
Cr86 retrieve case by case

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseEventDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseEventDTO.java
@@ -2,7 +2,6 @@ package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,8 +17,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CaseEventDTO implements Serializable {
-
-  private UUID id;
 
   private String description;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseRequestDTO.java
@@ -17,5 +17,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CaseRequestDTO implements Serializable {
 
-  private Boolean caseEvents;
+  private Boolean caseEvents = false;
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -291,6 +291,10 @@ paths:
             are provided in the response.
         '401':
           description: Unauthorised. The API key provided with the request is invalid.
+        '403':
+          description: Forbidden. The case exists, but it's not being returned as it's not a household case.
+        '404':
+          description: Not found. A case doesn't exist for the supplied uprn.
         '429':
           description: Server too busy. The ONS API is experiencing exceptional load.
         '500':

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -204,6 +204,10 @@ paths:
             are provided in the response.
         '401':
           description: Unauthorised. The API key provided with the request is invalid.
+        '403':
+          description: Forbidden. The case exists, but it's not being returned as it's not a household case.
+        '404':
+          description: Not found. A case doesn't exist for the supplied uprn.
         '429':
           description: Server too busy. The ONS API is experiencing exceptional load.
         '500':
@@ -243,6 +247,10 @@ paths:
             are provided in the response.
         '401':
           description: Unauthorised. The API key provided with the request is invalid.
+        '403':
+          description: Forbidden. The case exists, but it's being not returned as it's not a household case.
+        '404':
+          description: Not found. A case doesn't exist for the supplied caseId.
         '429':
           description: Server too busy. The ONS API is experiencing exceptional load.
         '500':
@@ -1364,8 +1372,6 @@ components:
               #/components/schemas/uk.gov.ons.responsemanagement.model.server.response.case.CaseEvent
     uk.gov.ons.responsemanagement.model.server.response.case.CaseEvent:
       properties:
-        id:
-          type: string
         category:
           type: string
         description:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -775,7 +775,7 @@ paths:
 info:
   title: ONS Contact Centre API
   description: Provides features and functions required by the Contact Centre.
-  version: "2.0.1-oas3"
+  version: "2.1.0-oas3"
 tags:
   - name: routes
 servers:


### PR DESCRIPTION
# Motivation and Context
This change contains minor modifications to support support CR-86 (which adds get by caseId to Contact Centre).

# What has changed
Changes of significance are:
Mainly:
- Removed id from case event DTO.
- Update error codes returned from the get case by caseId endpoint.
- Updated swagger version.

# How to test?
Run the Contact Centre unit tests.

# Links
See CR-86: https://collaborate2.ons.gov.uk/jira/browse/CR-86