### PR TITLE
increase length of productCode field from 6 to 12 so that it meets th…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
@@ -36,7 +36,7 @@ public class PostalFulfilmentRequestDTO implements Serializable {
   private String surname;
 
   @NotNull
-  @Size(max = 6)
+  @Size(max = 12)
   private String productCode;
 
   @NotNull private LocalDateTime dateTime;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalUnresolvedFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalUnresolvedFulfilmentRequestDTO.java
@@ -60,7 +60,7 @@ public class PostalUnresolvedFulfilmentRequestDTO implements Serializable {
   private String postcode;
 
   @NotBlank
-  @Size(max = 6)
+  @Size(max = 12)
   private String productCode;
 
   @NotNull private LocalDateTime dateTime;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSFulfilmentRequestDTO.java
@@ -31,7 +31,7 @@ public class SMSFulfilmentRequestDTO implements Serializable {
   private String telNo;
 
   @NotNull
-  @Size(max = 6)
+  @Size(max = 12)
   private String productCode;
 
   @NotNull private LocalDateTime dateTime;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSUnresolvedFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSUnresolvedFulfilmentRequestDTO.java
@@ -52,7 +52,7 @@ public class SMSUnresolvedFulfilmentRequestDTO implements Serializable {
   private String postcode;
 
   @NotBlank
-  @Size(max = 6)
+  @Size(max = 12)
   private String productCode;
 
   @NotNull private LocalDateTime dateTime;


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required so that the code in the contact-centre-service-api meets the swagger spec, which allows productCode values to be of length 12 or less.

# What has changed
The following four classes have been changed to specify productCode fields as having a length of 12 rather than 6 characters:
src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalUnresolvedFulfilmentRequestDTO.java
src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSFulfilmentRequestDTO.java
src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSUnresolvedFulfilmentRequestDTO.java


<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
This be tested by pointing the census-int-contact-centre service at the new version of the census-contact-centre-service-api (in the pom) and using postman as follows:

Firstly, compile and run the census-int-contact-centre service.

Then do a POST request to the following endpoint:
http://localhost:8171/cases/3fa85f64-5717-4562-b3fc-2c963f66afa6/fulfilment/post

NB The POST request will need to use the authorisation credentials given in the application.yml within the census-int-contact-centre service and it
should contain the following JSON:
{
 "caseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
 "title": "Mr",
 "forename": "Mickey",
 "surname": "Mouse",
 "productCode": "P_OR_H1",
 "dateTime": "2016-11-09T11:44:44.797"
}

If the contact-centre-service-api changes are working correctly then the following JSON response should come back:
{
    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
    "dateTime": "2019-05-15T14:11:38.390874"
}
