### PR TITLE
change classes to use java util Date

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressUpdateRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressUpdateRequestDTO.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.Date;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -78,5 +78,5 @@ public class AddressUpdateRequestDTO implements Serializable {
   @Size(max = 60)
   private String surname;
 
-  @NotNull private LocalDateTime dateTime;
+  @NotNull private Date dateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AppointmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AppointmentRequestDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.UUID;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -49,5 +49,5 @@ public class AppointmentRequestDTO implements Serializable {
   @Size(max = 60)
   private String surname;
 
-  @NotNull private LocalDateTime dateTime;
+  @NotNull private Date dateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -39,5 +39,5 @@ public class PostalFulfilmentRequestDTO implements Serializable {
   @Size(max = 12)
   private String productCode;
 
-  @NotNull private LocalDateTime dateTime;
+  @NotNull private Date dateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalUnresolvedFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalUnresolvedFulfilmentRequestDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.Date;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -63,5 +63,5 @@ public class PostalUnresolvedFulfilmentRequestDTO implements Serializable {
   @Size(max = 12)
   private String productCode;
 
-  @NotNull private LocalDateTime dateTime;
+  @NotNull private Date dateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.Date;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -63,5 +63,5 @@ public class RefusalRequestDTO implements Serializable {
 
   private UniquePropertyReferenceNumber uprn;
 
-  @NotNull private LocalDateTime dateTime;
+  @NotNull private Date dateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSFulfilmentRequestDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -34,5 +34,5 @@ public class SMSFulfilmentRequestDTO implements Serializable {
   @Size(max = 12)
   private String productCode;
 
-  @NotNull private LocalDateTime dateTime;
+  @NotNull private Date dateTime;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSUnresolvedFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSUnresolvedFulfilmentRequestDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.util.Date;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -55,5 +55,5 @@ public class SMSUnresolvedFulfilmentRequestDTO implements Serializable {
   @Size(max = 12)
   private String productCode;
 
-  @NotNull private LocalDateTime dateTime;
+  @NotNull private Date dateTime;
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because we have been instructed to use java.util.Date instead of java.time.LocalDateTime in our DTO classes

# What has changed
The following package now contains classes that use java.util.Date instead of java.time.LocalDateTime

uk.gov.ons.ctp.integration.contactcentresvc.representation

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
N/A