### PR TITLE
Removed DTO validations for fields in postal fulfilment request. Also…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
@@ -22,15 +22,12 @@ public class PostalFulfilmentRequestDTO {
 
   @NotNull private UUID caseId;
 
-  @NotNull
   @Size(max = 12)
   private String title;
 
-  @NotNull
   @Size(max = 60)
   private String forename;
 
-  @NotNull
   @Size(max = 60)
   private String surname;
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -386,7 +386,12 @@ paths:
       tags:
         - routes
       summary: Request a fulfilment for a Case
-      description: Request a fulfilment for a Case
+      description: >-
+        Request a fulfilment for a Case. 
+        If the fulfilment code is for a case type of household or communal 
+        individual (codes 'HI' or 'CI') then the request will be rejected as a bad 
+        request if any of the following fields are not provided in the request body: 
+        'title', 'forename' or 'surname'.
       parameters:
         - in: path
           name: caseId
@@ -905,9 +910,6 @@ components:
           description: The request date time stamp
       required:
         - caseId
-        - title
-        - forename
-        - surname
         - fulfilmentCode
         - dateTime
     uk.gov.ons.responsemanagement.model.server.request.unresolvedfulfilmentpost:


### PR DESCRIPTION
… updated swagger spec

# Motivation and Context
This change removes DTO level @notEmpty validation for postal fulfilment requests. This allows the contact centre to do equivalent validation of the fields concerned (title, forename & surname) for HI and CI cases. 

# What has changed
Postal fulfilment request DTO and swagger updated.  

# How to test?

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-228