### PR TITLE
CR70 Corrected response for respondent refusal

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -732,7 +732,7 @@ paths:
             application/json:
               schema:
                 $ref: >-
-                  #/components/schemas/uk.gov.ons.responsemanagement.model.server.response.response
+                  #/components/schemas/uk.gov.ons.responsemanagement.model.server.response.Response
         '400':
           description: >-
             Bad request. Indicates an issue with the request. Further details
@@ -1243,11 +1243,6 @@ components:
       required:
         - dateTime
 
-    uk.gov.ons.responsemanagement.model.server.response.response:
-      properties:
-        referenceid:
-          type: string
-          format: uuid
     uk.gov.ons.responsemanagement.model.server.response.fulfilmentcode:
       properties:
         fulfilmentCode:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -784,7 +784,7 @@ paths:
 info:
   title: ONS Contact Centre API
   description: Provides features and functions required by the Contact Centre.
-  version: "4.0.0-oas3"
+  version: "4.0.1-oas3"
 tags:
   - name: routes
 servers:


### PR DESCRIPTION
# Motivation and Context
CR70 implements the contact center endpoint for a respondent refusal.

This pull request is to correct the swagger, as it was previously specifying a response which only had the caseid. it now references the correct object type which has the caseid and a timestamp

# What has changed
Only swagger text. 

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-70