### PR TITLE
CR70 Removed address line 4 from DTO objects

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressUpdateRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressUpdateRequestDTO.java
@@ -48,9 +48,6 @@ public class AddressUpdateRequestDTO implements Serializable {
   @Size(max = 60)
   private String addressLine3;
 
-  @Size(max = 60)
-  private String addressLine4;
-
   @NotBlank
   @Size(max = 60)
   private String townName;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalUnresolvedFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalUnresolvedFulfilmentRequestDTO.java
@@ -44,9 +44,6 @@ public class PostalUnresolvedFulfilmentRequestDTO {
   @Size(max = 60)
   private String addressLine3;
 
-  @Size(max = 60)
-  private String addressLine4;
-
   @NotBlank
   @Size(max = 60)
   private String townName;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
@@ -49,9 +49,6 @@ public class RefusalRequestDTO {
   private String addressLine3;
 
   @Size(max = 60)
-  private String addressLine4;
-
-  @Size(max = 60)
   private String townName;
 
   @Size(max = 1)

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSUnresolvedFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/SMSUnresolvedFulfilmentRequestDTO.java
@@ -36,9 +36,6 @@ public class SMSUnresolvedFulfilmentRequestDTO {
   @Size(max = 60)
   private String addressLine3;
 
-  @Size(max = 60)
-  private String addressLine4;
-
   @NotBlank
   @Size(max = 60)
   private String townName;


### PR DESCRIPTION
# Motivation and Context
Removed all remaining references to 'addressLine4'. These were restricted to several request DTO's which still had an addressLine4 field.

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-70