### PR TITLE
CR289 Fix for json serialisation to string

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -40,6 +41,7 @@ public class CaseDTO {
 
   private String postcode;
 
+  @JsonUnwrapped
   private UniquePropertyReferenceNumber uprn;
 
   private List<CaseEventDTO> caseEvents;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/model/UniquePropertyReferenceNumber.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/model/UniquePropertyReferenceNumber.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation.model;
 
+import org.apache.commons.lang3.StringUtils;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.apache.commons.lang3.StringUtils;
 import uk.gov.ons.ctp.integration.contactcentresvc.Constants;
 
 @Data
@@ -24,5 +25,6 @@ public class UniquePropertyReferenceNumber {
     }
   }
 
+  @JsonProperty("uprn")
   private long value;
 }


### PR DESCRIPTION
# Motivation and Context
Fix to make Jackson serialise the value for uprn without an extra level in the serialised string.