### PR TITLE
CR289 Fix to force Jackson to serialise the uprn as a string

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/model/UniquePropertyReferenceNumber.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/model/UniquePropertyReferenceNumber.java
@@ -8,6 +8,12 @@ import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.ons.ctp.integration.contactcentresvc.Constants;
 
+/**
+ * If this class is included Jackson serialisation then you may want to simplify the generated
+ * string by removing an extra layer of output, so that the generated string can contain a 'uprn'
+ * value instead of showing the hierarchy of ownership. To do this annotate references to this class
+ * with '@JsonUnwrapped'.
+ */
 @Data
 @AllArgsConstructor
 public class UniquePropertyReferenceNumber {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/model/UniquePropertyReferenceNumber.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/model/UniquePropertyReferenceNumber.java
@@ -1,6 +1,8 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
@@ -26,5 +28,6 @@ public class UniquePropertyReferenceNumber {
   }
 
   @JsonProperty("uprn")
+  @JsonSerialize(using = ToStringSerializer.class)
   private long value;
 }


### PR DESCRIPTION
# Motivation and Context
Added Jackson annotation to force serialisation to convert the long uprn value to a string.

Here is the output from a manual test. Note the double quotes around the uprn value:
```
> curl -s -H "Content-Type: application/json" --user $CC_USERNAME:$CC_PASSWORD "$CC/cases/9347a654-4f13-11e9-8647-d663bd873d93?case-events=true" | jq | head -15
{
  "id": "9347a654-4f13-11e9-8647-d663bd873d93",
  "caseRef": "123123",
  "caseType": "HH",
  "createdDateTime": "2019-04-14T13:45:26.564+01:00",
  "addressLine1": "Napier House",
  "addressLine2": "11 Park Street",
  "addressLine3": "Parkhead",
  "townName": "Glasgow",
  "region": "E",
  "postcode": "G1 2AA",
  "uprn": "1347459999",
  "caseEvents": null
}
```

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-289