### PR TITLE
CR-643 Add countryCode, addressType, estabType to address search result

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
@@ -15,6 +15,7 @@ public class AddressDTO {
 
   private String addressType;
 
+  @LoggingScope(scope = Scope.SKIP)
   private String estabType;
 
   @LoggingScope(scope = Scope.SKIP)

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
@@ -11,6 +11,13 @@ public class AddressDTO {
 
   private String uprn;
 
+  private String countryCode;
+
+  private String addressType;
+
+  @LoggingScope(scope = Scope.SKIP)
+  private String estabType;
+
   @LoggingScope(scope = Scope.SKIP)
   private String formattedAddress;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
@@ -11,7 +11,7 @@ public class AddressDTO {
 
   private String uprn;
 
-  private String countryCode;
+  private String region;
 
   private String addressType;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressDTO.java
@@ -15,7 +15,6 @@ public class AddressDTO {
 
   private String addressType;
 
-  @LoggingScope(scope = Scope.SKIP)
   private String estabType;
 
   @LoggingScope(scope = Scope.SKIP)


### PR DESCRIPTION
# Motivation and Context
Amend Contact Centre API to add the attributes countryCode, addressType and estabType to the results for an address search by postcode or address string.

# What has changed
Addition of required attributes to AddressDTO representation.

# How to test?
Unit tests changed as required in Census Contact Centre Service repository interdependent [PR](https://github.com/ONSdigital/census-contact-centre-service/pull/34) which implements address search with new attributes added. Running the Contact Centre may be tested in Postman by issuing appropriate URL e.g. /addresses/postcode?postcode=EX1+2NP or addresses?input=5+Summerland+Gate+Belgrave Road+Exeter

# Notes
The Address Index Service has not yet implemented these additional attributes in the search results. The attributes will always be null until they send these attributes in the results. Have sent them expected JSON results we should receive from [task detailing attribute names](https://collaborate2.ons.gov.uk/jira/browse/FWMT-1853) on their backlog but they cannot guarantee this, discussions are apparently ongoing about options for meeting census requirements in Address Index. 