### PR TITLE
Update with new product reference fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ out/
 tools/addend/target/classes/
 
 target/**
-/target/
+

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ out/
 tools/addend/target/classes/
 
 target/**
+/target/

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentDTO.java
@@ -29,5 +29,7 @@ public class FulfilmentDTO {
 
   private DeliveryChannel deliveryChannel;
 
-  private boolean individual;
+  private Boolean individual;
+
+  private ProductGroup productGroup;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentDTO.java
@@ -19,7 +19,7 @@ public class FulfilmentDTO {
 
   private List<Region> regions;
 
-  private CaseType caseType;
+  private List<CaseType> caseTypes;
 
   private String fulfilmentCode;
 
@@ -28,4 +28,6 @@ public class FulfilmentDTO {
   private String description;
 
   private DeliveryChannel deliveryChannel;
+
+  private boolean individual;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentsRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentsRequestDTO.java
@@ -21,4 +21,6 @@ public class FulfilmentsRequestDTO {
   private Region region;
 
   private DeliveryChannel deliveryChannel;
+
+  private boolean individual;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentsRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentsRequestDTO.java
@@ -19,4 +19,6 @@ public class FulfilmentsRequestDTO {
   private CaseType caseType;
 
   private Region region;
+
+  private DeliveryChannel deliveryChannel;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentsRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/FulfilmentsRequestDTO.java
@@ -22,5 +22,7 @@ public class FulfilmentsRequestDTO {
 
   private DeliveryChannel deliveryChannel;
 
-  private boolean individual;
+  private Boolean individual;
+
+  private ProductGroup productGroup;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/ProductGroup.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/ProductGroup.java
@@ -1,0 +1,10 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.representation;
+
+public enum ProductGroup {
+  INVITE,
+  QUESTIONNAIRE,
+  CONTINUATION,
+  LARGE_PRINT,
+  UAC,
+  TRANSLATION
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This  change is required to allow the contact centre service to use the latest version (1.0.1) of the product reference library and to meet the requirements from card CR-737.

See swagger spec in GH census-contact-centre-service-api/swagger.yml