### PR TITLE
add 'allowedDeliveryChannels' attribute to the CaseDTO

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
@@ -30,6 +30,8 @@ public class CaseDTO {
 
   private String caseType;
 
+  private List<DeliveryChannel> allowedDeliveryChannels;
+
   private Date createdDateTime;
 
   private String addressLine1;


### PR DESCRIPTION
A simple change to add the 'allowedDeliveryChannels' attribute to the CaseDTO, as per the swagger spec
