### PR TITLE
Cr 746

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
@@ -1,12 +1,12 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.godaddy.logging.LoggingScope;
 import com.godaddy.logging.Scope;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -53,13 +53,11 @@ public class CaseDTO {
   @JsonUnwrapped private UniquePropertyReferenceNumber uprn;
 
   private List<CaseEventDTO> caseEvents;
-  
+
   private boolean handDelivery;
 
   @JsonIgnore
   public boolean isHandDelivery() {
     return handDelivery;
   }
-  
-  
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import com.godaddy.logging.LoggingScope;
-import com.godaddy.logging.Scope;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.godaddy.logging.LoggingScope;
+import com.godaddy.logging.Scope;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -52,4 +53,13 @@ public class CaseDTO {
   @JsonUnwrapped private UniquePropertyReferenceNumber uprn;
 
   private List<CaseEventDTO> caseEvents;
+  
+  private boolean handDelivery;
+
+  @JsonIgnore
+  public boolean isHandDelivery() {
+    return handDelivery;
+  }
+  
+  
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This  change is required because RM are adding a new field to their case api service this sprint (starting 11/2/20)

The new field name in RM Case API response is 'handDelivery', it is of type boolean.

# What has changed
This change adds the handDelivery field to the CaseDTO so that it can be used to determine the values for the 'allowedDeliveryChannels' list:
if (caseType == SPG && handDelivery == true) [SMS] else [SMS,POST]

However, since the CaseDTO is used by Serco, who should not see the value of the handDelivery field, it has also been necessary to add an @JsonIgnore annotation over the isHandDelivery() getter.






