### PR TITLE
Add addressType to CaseDTO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ tools/addend/target/classes/
 
 target/**
 
+/target/

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
@@ -31,6 +31,8 @@ public class CaseDTO {
 
   private String caseType;
 
+  private String addressType;
+
   private List<DeliveryChannel> allowedDeliveryChannels;
 
   private Date createdDateTime;


### PR DESCRIPTION
I have added the addressType field to the CaseDTO, which is the response body that Serco receive when they call any of the three GET case endpoints in the CCSVC.
