### PR TITLE
amend PostalFulfilmentRequestDTO so that fulfilmentCode fields have n…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
@@ -36,9 +36,7 @@ public class PostalFulfilmentRequestDTO {
   @LoggingScope(scope = Scope.SKIP)
   private String surname;
 
-  @NotNull
-  @Size(max = 12)
-  private String fulfilmentCode;
+  @NotNull private String fulfilmentCode;
 
   @NotNull private Date dateTime;
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because the product reference library has no restriction on the possible length of fulfilment codes and already contains some codes that are greater than length 12, which is the length that the CCSVC API currently uses to validate fulfilment codes.

# How to test?
These changes can be tested using postman by doing as follows:
1. Run rabbitmq and mock case service 
2. Amend the pom of the CCSVC so that it is pointing to this snapshot of the CCSVC API (version 0.0.74-SNAPSHOT)
3. Run the amended contact centre service.
4. Open postman and create the folling POST URL:

http://localhost:8171/cases/3305e937-6fb1-4ce1-9d4c-077f147789aa/fulfilment/post

In the request body enter the following:

{
	"caseId": "3305e937-6fb1-4ce1-9d4c-077f147789aa",
	"title": "Mrs",
	"forename": "Sally",
	"surname": "Smith",
	"fulfilmentCode": "P_UAC_UACHHP4",
	"dateTime": "2019-04-14T13:45:26.564+01:00"
}

Use basic authentication for the CCSVC and then send the request. If all is well then you should not get a validation error. Otherwise, without these changes, a validation error will occur.