### PR TITLE
CR-937 EstabType and EstabDescription added to CaseDTO

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTO.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.domain.EstabType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 
 /**
@@ -31,6 +32,10 @@ public class CaseDTO {
   private String caseType;
 
   private String addressType;
+
+  private EstabType estabType;
+
+  private String estabDescription;
 
   private List<DeliveryChannel> allowedDeliveryChannels;
 


### PR DESCRIPTION
# Motivation and Context
Amend Contact Centre Service API to add the attributes estabType and estabDescription to the results for a Case search by Id, caseRef or UPRN.

# What has changed
Addition of required attributes to CaseDTO representation.

# How to test?
Unit tests changed as required in Census Contact Centre Service repository. To be delivered when this dependency is available as a Release version.