### PR TITLE
CR-985 add callId to to refusal DTO

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
@@ -75,4 +75,6 @@ public class RefusalRequestDTO {
   private UniquePropertyReferenceNumber uprn;
 
   @NotNull private Date dateTime;
+
+  @NotNull private String callId;
 }

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: ONS Contact Centre API
   description: Provides features and functions required by the Contact Centre.
-  version: "5.10.5-oas3"
+  version: "5.10.6-oas3"
 security:
   - basicAuth: []
 tags:
@@ -1084,8 +1084,12 @@ components:
           type: string
           format: datetime
           description: The requested time of the refusal
+        callId:
+          type: string
+          description: call identifier
       required:
         - agentId
+        - callId
         - caseId
         - reason
         - dateTime

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: ONS Contact Centre API
   description: Provides features and functions required by the Contact Centre.
-  version: "5.11.5-oas3"
+  version: "5.11.6-oas3"
 security:
   - basicAuth: []
 tags:
@@ -1086,6 +1086,9 @@ components:
           type: string
           format: datetime
           description: The requested time of the refusal
+        callId:
+          type: string
+          description: call identifier
       required:
         - agentId
         - callId


### PR DESCRIPTION
# Motivation and Context
CR-985 requires a call-Id to be added to the Refusal DTO

Also, the swagger-future YAML  was missing the calId section , so that was added. And the relevant callId parts were added to the swagger-current YAML. 

