### PR TITLE
CR-976 add UPRN description to describe null meaning

### DIFF
--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: ONS Contact Centre API
   description: Provides features and functions required by the Contact Centre.
-  version: "5.10.6-oas3"
+  version: "5.10.7-oas3"
 security:
   - basicAuth: []
 tags:
@@ -1383,6 +1383,7 @@ components:
             - NA
         uprn:
           type: string
+          description: 'The Unique Property Reference Number, or null if the address is historic'
         formattedAddress:
           type: string
         welshFormattedAddress:

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: ONS Contact Centre API
   description: Provides features and functions required by the Contact Centre.
-  version: "5.11.6-oas3"
+  version: "5.11.7-oas3"
 security:
   - basicAuth: []
 tags:
@@ -1389,6 +1389,7 @@ components:
             - NA
         uprn:
           type: string
+          description: 'The Unique Property Reference Number, or null if the address is historic'
         formattedAddress:
           type: string
         welshFormattedAddress:


### PR DESCRIPTION
# Motivation and Context
Make it clear in the swagger the meaning when an AddressDTO UPRN is null (ie it is historical) as agreed in the new CR-976 requirements.

This is just a description update in the swagger files.
