### PR TITLE
CR-1047 Extend UPRN validation to allow 13 digits.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.58</version>
+      <version>0.0.62</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>
-      <version>0.0.15</version>
+      <version>0.0.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/Constants.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/Constants.java
@@ -1,9 +1,6 @@
 package uk.gov.ons.ctp.integration.contactcentresvc;
 
 public interface Constants {
-  public static final String UPRN_RE = "^\\d{1,12}$";
-  public static final long UPRN_MIN = 0L;
-  public static final long UPRN_MAX = 999999999999L;
 
   public static final String UKMOBILEPHONENUMBER_RE = "^447[0-9]{9}$";
   public static final String OPTIONAL_UKMOBILEPHONENUMBER_RE = "^$|" + UKMOBILEPHONENUMBER_RE;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/NewCaseRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/NewCaseRequestDTO.java
@@ -7,6 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.EstabType;
+import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 
 /**
  * The request object when contact centre sends new case and address details
@@ -21,7 +22,7 @@ public class NewCaseRequestDTO extends CaseRequestDTO {
 
   @NotNull private CaseType caseType;
 
-  private String uprn;
+  private UniquePropertyReferenceNumber uprn;
 
   @NotNull private EstabType estabType;
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTOTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseDTOTest.java
@@ -10,7 +10,7 @@ import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 
 public class CaseDTOTest {
   private static final UniquePropertyReferenceNumber A_UPRN =
-      new UniquePropertyReferenceNumber("334111111111");
+      new UniquePropertyReferenceNumber("3341111111111");
   private static final UniquePropertyReferenceNumber ANOTHER_UPRN =
       new UniquePropertyReferenceNumber("1347459999");
   private static final UUID A_UUID = UUID.randomUUID();

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -1,13 +1,14 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.10.8-oas3"
+  version: "5.10.9-oas3"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects the release candidate that will next be promoted into the integration environment.
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.10.9  | uprn now 13 not 12 digits    
     5.10.8  | AD location len 8 -> 4
       -     | 202 response added to launch endpoint
     5.10.7  | ceOrgName added to Case response
@@ -234,7 +235,7 @@ paths:
           description: 'Lookup a case by the UPRN '
           schema:
             type: string
-            pattern: '^\d{1,12}$'
+            pattern: '^\d{1,13}$'
         - in: query
           name: caseEvents
           description: true if case events are additionally required
@@ -913,7 +914,7 @@ components:
               $ref: '#/components/schemas/CaseType'
             uprn:
               type: string
-              pattern: '^\d{1,12}$'
+              pattern: '^\d{1,13}$'
               description: The address UPRN if known, or null if not known.
             estabType:
               $ref: '#/components/schemas/EstabType'
@@ -1035,7 +1036,7 @@ components:
           $ref: '#/components/schemas/POSTCODE_CONST'
         uprn:
           type: string
-          pattern: '^\d{1,12}$'
+          pattern: '^\d{1,13}$'
           description: The address UPRN if known
         dateTime:
           type: string


### PR DESCRIPTION
# Motivation and Context
UPRNs generated for skeleton cases by RM have an additional leading digit, needing to allow for 13 digits.

# What has changed
POM dependencies changed to include new UniquePropertyReferenceNumber allowing for 13 digits.
Contants static attributes never used and duplicated in UniquePropertyReferenceNumber removed.
NewCaseRequestDTO altered to use UniquePropertyReferenceNumber as opposed to String for UPRN.

# How to test?
Unit test adjusted with 13 rather than 12 digit value.

# Links
https://github.com/ONSdigital/census-int-common-service/pull/44
