### PR TITLE
Cr 973 put case endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>contactcentreserviceapi</artifactId>
   <!-- Please make sure that contact-centre-cucumber has the latest dependency on this project -->
-  <version>0.0.119-CR973-SNAPSHOT</version>
+  <version>0.0.119-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ContactCentreServiceApi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>contactcentreserviceapi</artifactId>
   <!-- Please make sure that contact-centre-cucumber has the latest dependency on this project -->
-  <version>0.0.116-SNAPSHOT</version>
+  <version>0.0.116-CR973-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ContactCentreServiceApi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.58</version>
+      <version>0.0.62</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/CaseRequestDTO.java
@@ -5,17 +5,20 @@ import com.godaddy.logging.Scope;
 import java.util.Date;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.ons.ctp.integration.contactcentresvc.Constants;
+import uk.gov.ons.ctp.common.domain.CaseType;
+import uk.gov.ons.ctp.common.domain.EstabType;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public abstract class CaseRequestDTO {
+
+  @NotNull private CaseType caseType;
+  @NotNull private EstabType estabType;
 
   @NotBlank
   @Size(max = 60)
@@ -28,17 +31,6 @@ public abstract class CaseRequestDTO {
   @LoggingScope(scope = Scope.SKIP)
   @Size(max = 60)
   private String addressLine3;
-
-  @LoggingScope(scope = Scope.SKIP)
-  @NotBlank
-  @Size(max = 60)
-  private String townName;
-
-  @NotNull private Region region;
-
-  @NotBlank
-  @Pattern(regexp = Constants.POSTCODE_RE)
-  private String postcode;
 
   @NotNull private Date dateTime;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/ModifyCaseRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/ModifyCaseRequestDTO.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import uk.gov.ons.ctp.common.domain.EstabType;
 
 /**
  * The request object when contact centre calls to modify the details for a case
@@ -22,6 +21,4 @@ import uk.gov.ons.ctp.common.domain.EstabType;
 public class ModifyCaseRequestDTO extends CaseRequestDTO {
 
   @NotNull private UUID caseId;
-
-  @NotNull private EstabType estabType;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/NewCaseRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/NewCaseRequestDTO.java
@@ -1,12 +1,16 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
+import com.godaddy.logging.LoggingScope;
+import com.godaddy.logging.Scope;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import uk.gov.ons.ctp.common.domain.CaseType;
-import uk.gov.ons.ctp.common.domain.EstabType;
+import uk.gov.ons.ctp.integration.contactcentresvc.Constants;
 
 /**
  * The request object when contact centre sends new case and address details
@@ -19,9 +23,16 @@ import uk.gov.ons.ctp.common.domain.EstabType;
 @AllArgsConstructor
 public class NewCaseRequestDTO extends CaseRequestDTO {
 
-  @NotNull private CaseType caseType;
-
   private String uprn;
 
-  @NotNull private EstabType estabType;
+  @LoggingScope(scope = Scope.SKIP)
+  @NotBlank
+  @Size(max = 60)
+  private String townName;
+
+  @NotNull private Region region;
+
+  @NotBlank
+  @Pattern(regexp = Constants.POSTCODE_RE)
+  private String postcode;
 }

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -1,13 +1,14 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.10.9-oas3"
+  version: "5.10.10-oas3"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects the release candidate that will next be promoted into the integration environment.
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.10.10 | PUT /cases/{caseId} address fields reduced
     5.10.9  | uprn now 13 not 12 digits    
     5.10.8  | AD location len 8 -> 4
       -     | 202 response added to launch endpoint
@@ -820,6 +821,8 @@ components:
     CaseRequestDTO:
       type: object
       properties:
+        caseType:
+              $ref: '#/components/schemas/CaseType'
         addressLine1:
           type: string
           maxLength: 60
@@ -832,14 +835,6 @@ components:
           type: string
           maxLength: 60
           description: updated address line3
-        townName:
-          type: string
-          maxLength: 30
-          description: The post town of the address
-        region:
-          $ref: '#/components/schemas/Region'
-        postcode:
-          $ref:  '#/components/schemas/POSTCODE_CONST'
         ceOrgName:
           type: string
           maxLength: 60
@@ -847,10 +842,55 @@ components:
         ceUsualResidents:
           type: integer
           description: CE number of usual residents. Must be a positive value for CE cases
+        estabType:
+          $ref: '#/components/schemas/EstabType'
+          description: 'the reported type of an address'
         dateTime:
           type: string
           format: datetime
           description: The request date time stamp
+
+    ModifyCaseRequestDTO:
+      allOf:
+        - $ref: '#/components/schemas/CaseRequestDTO'
+        - type: object
+          properties:
+            caseId:
+              type: string
+              format: uuid
+              description: CaseId of case to modify
+          required:
+            - caseId
+            - caseType
+            - estabType
+            - addressLine1
+            - dateTime
+
+    NewCaseRequestDTO:
+      allOf:
+        - $ref: '#/components/schemas/CaseRequestDTO'
+        - type: object
+          properties:
+            uprn:
+              type: string
+              pattern: '^\d{1,13}$'
+              description: The address UPRN if known, or null if not known.
+            region:
+              $ref: '#/components/schemas/Region'
+            postcode:
+              $ref:  '#/components/schemas/POSTCODE_CONST'
+            townName:
+              type: string
+              maxLength: 30
+              description: The post town of the address
+          required:
+            - caseType
+            - estabType
+            - region
+            - addressLine1
+            - townName
+            - postcode
+            - dateTime
 
     InvalidateCaseRequestDTO:
       properties:
@@ -882,50 +922,6 @@ components:
         - status
         - caseId
         - dateTime
-
-    ModifyCaseRequestDTO:
-      allOf:
-        - $ref: '#/components/schemas/CaseRequestDTO'
-        - type: object
-          properties:
-            caseId:
-              type: string
-              format: uuid
-              description: CaseId of case to modify
-            estabType:
-              $ref: '#/components/schemas/EstabType'
-          description: 'the reported status of an address'
-        - type: object
-          required:
-            - region
-            - caseId
-            - addressLine1
-            - townName
-            - estabType
-            - postcode
-            - dateTime
-
-    NewCaseRequestDTO:
-      allOf:
-        - $ref: '#/components/schemas/CaseRequestDTO'
-        - type: object
-          properties:
-            caseType:
-              $ref: '#/components/schemas/CaseType'
-            uprn:
-              type: string
-              pattern: '^\d{1,13}$'
-              description: The address UPRN if known, or null if not known.
-            estabType:
-              $ref: '#/components/schemas/EstabType'
-          required:
-            - region
-            - addressLine1
-            - townName
-            - postcode
-            - dateTime
-            - caseType
-            - estabType
 
     PostalFulfilmentRequestDTO:
       properties:


### PR DESCRIPTION
# Motivation and Context
CR-973 requires changes to the DTO classes support the PUT case for modification endpoint. The swagger is also updated to match.

# What has changed
- relevant parts of future swagger copied to current swagger
- DTO objects supporting address modification or type change are modified to fit requirement

