### PR TITLE
CR-1063 Updating version number of current swagger

### DIFF
--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.10.10-oas3"
+  version: "5.10.11-oas3"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects the release candidate that will next be promoted into the integration environment.


### PR DESCRIPTION
Updating version number is swagger-current. 
Missed this earlier and Rob only spotted it after the previous PR was merged.