### PR TITLE
CR-809_Add_AD_get_UAC_endpoint

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/UACRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/UACRequestDTO.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
-import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,9 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UACRequestDTO {
 
-  @NotNull private UUID caseId;
+  @NotNull private String adLocationId;
 
-  @NotNull private String adLocation;
-
-  @NotNull private boolean individual;
+  @NotNull private Boolean individual;
 }


### PR DESCRIPTION
# Motivation and Context
Adjust DTO to conform to swagger spec for AD operative to obtain a UAC for a caseId. 

# What has changed
Minor change to UACRequestDTO required for implementation in census-contact-centre-service.