### PR TITLE
CR-1114 take of 5 digit restriction from agentId. Update swagger and …

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/LaunchRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/LaunchRequestDTO.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,9 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LaunchRequestDTO {
 
-  @Pattern(regexp = "\\d{1,5}")
-  @NotNull
-  private String agentId;
+  @NotNull private Integer agentId;
 
   @NotNull private Boolean individual;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
@@ -26,9 +26,7 @@ public class RefusalRequestDTO {
 
   private String caseId;
 
-  @Pattern(regexp = "\\d{1,5}")
-  @NotNull
-  private String agentId;
+  @NotNull private Integer agentId;
 
   @Size(max = 12)
   @LoggingScope(scope = Scope.SKIP)

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -1,13 +1,14 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.10.11-oas3"
+  version: "5.10.12-oas3"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects the release candidate that will next be promoted into the integration environment.
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.10.12 | unrestricted integer agentId
     5.10.11 | removed tele num and notes from /cases/refusal
       -     | added isHouseholder to /cases/refusal
       -     | callId optional for /cases/refusal
@@ -468,8 +469,7 @@ paths:
           required: true
           description: employee identifier
           schema:
-            type: string
-            pattern: '^\d{1,5}$'
+            $ref: '#/components/schemas/AGENT_ID_CONST'
         - in: query
           name: individual
           required: true
@@ -984,9 +984,7 @@ components:
           type: string
           description: CaseId to log refusal against
         agentId:
-          type: string
-          pattern: '^\d{1,5}$'
-          description: employee identifier
+          $ref: '#/components/schemas/AGENT_ID_CONST'
         reason:
           type: string
           enum:
@@ -1269,6 +1267,11 @@ components:
     POSTCODE_CONST:
       type: string
       pattern: 'GIR[ ]?0AA|((AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|BX|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(\\d[\\dA-Z]?[ ]?\\d[ABD-HJLN-UW-Z]{2}))|BFPO[ ]?\\d{1,4}'
+
+    AGENT_ID_CONST:
+      type: integer
+      format: int32
+      description: employee identifier
       
     Region:
       type: string

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -1267,6 +1267,7 @@ components:
     AGENT_ID_CONST:
       type: integer
       format: int32
+      description: employee identifier
       
     Region:
       type: string


### PR DESCRIPTION
…DTOs

# Motivation and Context
It has been agreed that agentId should be an unrestricted integer rather than a 5 digit string.

# What has changed
- agentID in the swagger copied from future to current
- minor enhancement to future swagger to add description to schema.  Agreed with @philwhiles  that this does not need a version bump.
- Refusal and Launch DTO agentId type changed from String to Integer.

