### PR TITLE
Cr 1160 removed unknown from refusuals endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>contactcentreserviceapi</artifactId>
   <!-- Please make sure that contact-centre-cucumber has the latest dependency on this project -->
-  <version>0.0.126-SNAPSHOT</version>
+  <version>0.0.126-SNAPSHOT-CR1160</version>
   <packaging>jar</packaging>
 
   <name>CTP : ContactCentreServiceApi</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>contactcentreserviceapi</artifactId>
   <!-- Please make sure that contact-centre-cucumber has the latest dependency on this project -->
-  <version>0.0.126-SNAPSHOT-CR1160</version>
+  <version>0.0.126-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ContactCentreServiceApi</name>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/RefusalRequestDTO.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 import com.godaddy.logging.LoggingScope;
 import com.godaddy.logging.Scope;
 import java.util.Date;
+import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -24,7 +25,7 @@ import uk.gov.ons.ctp.integration.contactcentresvc.Constants;
 @AllArgsConstructor
 public class RefusalRequestDTO {
 
-  private String caseId;
+  @NotNull private UUID caseId;
 
   @NotNull private Integer agentId;
 

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -8,6 +8,8 @@ info:
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.10.13 | removed support for 'unknown' from /cases/refusal. Also, the
+            | caseId in the request body can no longer be null.
     5.10.12 | unrestricted integer agentId
     5.10.11 | removed tele num and notes from /cases/refusal
       -     | added isHouseholder to /cases/refusal
@@ -717,12 +719,12 @@ paths:
         - CONTACT_CENTRE
       summary: Log when someone is unable/unwilling to complete a response
       description: >-
-        Logs a refusal against a Case, 'unknown' should be used in place of a caseid if lookup cannot be performed due to API not being available.
+        Logs a refusal against a Case.
         Address fields are optional, these are only required in the instance where the API is down and the contact centre operative needs to record the address fields due to Case lookup not being available.
       parameters:
         - in: path
           name: caseId
-          description: The Case UUID or 'unknown'
+          description: The Case UUID
           required: true
           schema:
             type: string
@@ -982,6 +984,7 @@ components:
       properties:
         caseId:
           type: string
+          format: uuid
           description: CaseId to log refusal against
         agentId:
           $ref: '#/components/schemas/AGENT_ID_CONST'

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.10.12-oas3"
+  version: "5.10.13-oas3"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects the release candidate that will next be promoted into the integration environment.

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.11.12"
+  version: "5.11.13"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects upcoming changes
@@ -962,7 +962,7 @@ components:
           description: CaseId to request fulfilment for.
         telNo:
           type: string
-          pattern: '^447[0-9]{9}$'  
+          pattern: '^447[0-9]{9}$'
         fulfilmentCode:
           type: string
           description: the fulfilment code for the fulfilment

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -8,6 +8,8 @@ info:
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.11.13 | removed support for 'unknown' from /cases/refusal. Also, the
+            | caseId in the request body can no longer be null.
     5.11.12 | callId optional for /cases/refusal
     5.11.11 | removed tele num and notes from /cases/refusal
       -     | added isHouseholder to /cases/refusal
@@ -713,12 +715,12 @@ paths:
         - CONTACT_CENTRE
       summary: Log when someone is unable/unwilling to complete a response
       description: >-
-        Logs a refusal against a Case, 'unknown' should be used in place of a caseid if lookup cannot be performed due to API not being available.
+        Logs a refusal against a Case.
         Address fields are optional, these are only required in the instance where the API is down and the contact centre operative needs to record the address fields due to Case lookup not being available.
       parameters:
         - in: path
           name: caseId
-          description: The Case UUID or 'unknown'
+          description: The Case UUID
           required: true
           schema:
             type: string
@@ -978,6 +980,7 @@ components:
       properties:
         caseId:
           type: string
+          format: uuid
           description: CaseId to log refusal against
         agentId:
           $ref: '#/components/schemas/AGENT_ID_CONST'


### PR DESCRIPTION
Refusals endpoint no longer supports the 'unknown' caseId.
The knockon impact of this is the caseId can now become a UUID instead of a String.
Swagger documentation updated to reflect these changes.