### PR TITLE
CR-1167 Updated max values of offset and limit to 5000

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressQueryRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressQueryRequestDTO.java
@@ -12,11 +12,11 @@ public class AddressQueryRequestDTO {
   @NotBlank private String input;
 
   @Min(0)
-  @Max(5000)
+  @Max(250)
   private Integer offset = 0;
 
   @Min(0)
-  @Max(5000)
+  @Max(100)
   private Integer limit = 100;
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressQueryRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressQueryRequestDTO.java
@@ -12,11 +12,11 @@ public class AddressQueryRequestDTO {
   @NotBlank private String input;
 
   @Min(0)
-  @Max(250)
+  @Max(5000)
   private Integer offset = 0;
 
   @Min(0)
-  @Max(100)
+  @Max(5000)
   private Integer limit = 100;
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostcodeQueryRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostcodeQueryRequestDTO.java
@@ -16,11 +16,11 @@ public class PostcodeQueryRequestDTO {
   private String postcode;
 
   @Min(0)
-  @Max(250)
+  @Max(5000)
   private Integer offset = 0;
 
   @Min(0)
-  @Max(100)
+  @Max(5000)
   private Integer limit = 100;
 
   /**

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -8,7 +8,7 @@ info:
 
     Version | Change
     ------- | ----------------------------------------------------------------
-    5.10.15 | updated maximum values of offset and limit
+    5.10.15 | updated maximum values of offset and limit for /addresses/postcode endpoint
     5.10.14 | updated the EstabType enum
     5.10.13 | removed support for 'unknown' from /cases/refusal. Also, the
             | caseId in the request body can no longer be null.

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -61,7 +61,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 5000
+            maximum: 250
             default: 0
         - in: query
           name: limit
@@ -70,7 +70,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 5000
+            maximum: 100
             default: 100
 
       responses:
@@ -116,7 +116,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 250
+            maximum: 5000
             default: 0
         - in: query
           name: limit
@@ -125,7 +125,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 100
+            maximum: 5000
             default: 100
       responses:
         '200':

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -1,13 +1,14 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.10.14-oas3"
+  version: "5.10.15-oas3"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects the release candidate that will next be promoted into the integration environment.
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.10.15 | updated maximum values of offset and limit
     5.10.14 | updated the EstabType enum
     5.10.13 | removed support for 'unknown' from /cases/refusal. Also, the
             | caseId in the request body can no longer be null.
@@ -60,7 +61,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 250
+            maximum: 5000
             default: 0
         - in: query
           name: limit
@@ -69,7 +70,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 100
+            maximum: 5000
             default: 100
 
       responses:

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -8,7 +8,7 @@ info:
 
     Version | Change
     ------- | ----------------------------------------------------------------
-    5.11.15 | updated maximum values of offset and limit
+    5.11.15 | updated maximum values of offset and limit for /addresses/postcode endpoint
     5.11.14 | updated the EstabType enum
     5.11.13 | removed support for 'unknown' from /cases/refusal. Also, the
             | caseId in the request body can no longer be null.

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -1,13 +1,14 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.11.14"
+  version: "5.11.15"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects upcoming changes
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.11.15 | updated maximum values of offset and limit
     5.11.14 | updated the EstabType enum
     5.11.13 | removed support for 'unknown' from /cases/refusal. Also, the
             | caseId in the request body can no longer be null.
@@ -55,7 +56,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 250
+            maximum: 5000
             default: 0
         - in: query
           name: limit
@@ -64,7 +65,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 100
+            maximum: 5000
             default: 100
 
       responses:

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -56,7 +56,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 5000
+            maximum: 250
             default: 0
         - in: query
           name: limit
@@ -65,7 +65,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 5000
+            maximum: 100
             default: 100
 
       responses:
@@ -111,7 +111,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 250
+            maximum: 5000
             default: 0
         - in: query
           name: limit
@@ -120,7 +120,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 100
+            maximum: 5000
             default: 100
       responses:
         '200':


### PR DESCRIPTION
# Motivation and Context
To allow Serco to get more than 250 address.
# What has changed
<!--- What code changes has been made -->
Updated the maximum value of offset and limit to 5000.
Changed the current and future swagger accordingly.


# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1167