### PR TITLE
Cr 1605 change max field values for postal fulfilments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,19 +16,19 @@
   <parent>
     <groupId>uk.gov.ons.ctp.integration</groupId>
     <artifactId>census-int-common-config</artifactId>
-    <version>0.0.15</version>
+    <version>0.0.17</version>
   </parent>
 
   <dependencies>
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.70</version>
+      <version>0.0.72</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>
-      <version>0.0.16</version>
+      <version>0.0.17</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/PostalFulfilmentRequestDTO.java
@@ -24,15 +24,15 @@ public class PostalFulfilmentRequestDTO {
 
   @NotNull private UUID caseId;
 
-  @Size(max = 12)
+  @Size(max = 20)
   @LoggingScope(scope = Scope.SKIP)
   private String title;
 
-  @Size(max = 60)
+  @Size(max = 35)
   @LoggingScope(scope = Scope.SKIP)
   private String forename;
 
-  @Size(max = 60)
+  @Size(max = 35)
   @LoggingScope(scope = Scope.SKIP)
   private String surname;
 

--- a/swagger-current.yml
+++ b/swagger-current.yml
@@ -1,13 +1,14 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.10.16-oas3"
+  version: "5.10.17-oas3"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects the release candidate that will next be promoted into the integration environment.
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.11.17 | postalfulfilment title, forename and surname max characters changes (20,35,35)
     5.10.16 | title no longer mandatory for an individual fulfilment postal request
     5.10.15 | updated maximum values of offset and limit for /addresses/postcode endpoint
     5.10.14 | updated the EstabType enum
@@ -939,15 +940,15 @@ components:
           description: CaseId to request fulfilment for.
         title:
           type: string
-          maxLength: 12
+          maxLength: 20
           description: the title of the person requesting fulfilment
         forename:
           type: string
-          maxLength: 60
+          maxLength: 35
           description: the forename of the person requesting fulfilment
         surname:
           type: string
-          maxLength: 60
+          maxLength: 35
           description: the surname of the person requesting fulfilment
         fulfilmentCode:
           type: string

--- a/swagger-future.yml
+++ b/swagger-future.yml
@@ -1,13 +1,14 @@
 openapi: 3.0.0
 info:
   title: ONS Contact Centre API
-  version: "5.11.16"
+  version: "5.11.17"
   description: |
     Specification for the ONS Census Contact Centre / Assisted Digital service.
     This reflects upcoming changes
 
     Version | Change
     ------- | ----------------------------------------------------------------
+    5.11.17 | postalfulfilment title, forename and surname max characters changes (20,35,35)
     5.11.16 | title no longer mandatory for an individual fulfilment postal request
     5.11.15 | updated maximum values of offset and limit for /addresses/postcode endpoint
     5.11.14 | updated the EstabType enum
@@ -935,15 +936,15 @@ components:
           description: CaseId to request fulfilment for.
         title:
           type: string
-          maxLength: 12
+          maxLength: 20
           description: the title of the person requesting fulfilment
         forename:
           type: string
-          maxLength: 60
+          maxLength: 35
           description: the forename of the person requesting fulfilment
         surname:
           type: string
-          maxLength: 60
+          maxLength: 35
           description: the surname of the person requesting fulfilment
         fulfilmentCode:
           type: string


### PR DESCRIPTION
# Motivation and Context
The max field lengths of title, forename and surname in PostalFulfilmentDTO and its swagger representations are wrong.
They were 16, 60, 60 and should be 20, 35, 35 characters in length respectively

# What has changed
PostalFulfilmentDTO - amended field sizes
swagger-current.yml - amended field sizes
swagger-future.yml - amended field sizes
Updated POM dependencies

# How to test?
This build will be pushed and its dependency will be updated in CCSERV and CCCUC
The Unit tests in CCServ will be run
The Cumber tests will be run
