### PR TITLE
CR-1814 restrict address query input field to 250 characters in line …

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressQueryRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/representation/AddressQueryRequestDTO.java
@@ -3,13 +3,17 @@ package uk.gov.ons.ctp.integration.contactcentresvc.representation;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import lombok.Data;
 import lombok.ToString;
 
 @Data
 @ToString
 public class AddressQueryRequestDTO {
-  @NotBlank private String input;
+
+  @Size(max = 250)
+  @NotBlank
+  private String input;
 
   @Min(0)
   @Max(250)


### PR DESCRIPTION
…with the swagger

# Motivation and Context
- In production we found an agent blowing the AIMS limit for input with 1000's of trailing spaces.
- We have also found that the 250 max limit in the swagger is not being enforced.


# What has changed
- 250 max limit added to DTO object on input field.

See https://collaborate2.ons.gov.uk/jira/browse/CR-1814